### PR TITLE
購入直後のBP35A1でスマートメータから値取得できない

### DIFF
--- a/bp35a1.h
+++ b/bp35a1.h
@@ -44,6 +44,8 @@ public:
   void setEchoCallback(bool isEnable); // コマンドエコーバックを変更する
   void deleteSession();                // 以前のPANAセッションを解除する
   bool getVersion();                   // バージョン情報を取得する
+  bool getAsciiMode();                 // BP35A1のASCII出力モードを確認する
+  bool assureAsciiMode();
 
   bool setPassword(const char *pass); // B ルートの PASSWORD を設定する
   bool setId(const char *id);         // B ルートの ID を設定する
@@ -87,6 +89,9 @@ private:
   bool waitIpv6AddrResponse();
   bool requestConnection(); // PANN 接続要求を送信する
   bool waitConnection();    // PANA 接続完了を待つ
+
+  bool setAsciiMode(bool use_ascii_mode);
+  bool waitRoptResponse();  // ROPTコマンドの応答を待つ
 
   bool sendUdp(std::vector<byte> data);
   bool waitUpdResponse(const int timeout = READ_TIMEOUT);

--- a/examples/M5StickC/M5StickC.ino
+++ b/examples/M5StickC/M5StickC.ino
@@ -19,6 +19,13 @@ bool connectWiSun(const char *id, const char *password)
   nextConnectStep("delete session");
   bp35a1.deleteSession();
 
+  // BP35A1のASCII変換モードがonである事を確認
+  if (!bp35a1.assureAsciiMode())
+  {
+    Serial.println("BP35A1::assure ascii mode failed");
+    return false;
+  }
+
   // B ルートの PASSWORD を送信
   nextConnectStep("set password");
   if (!bp35a1.setPassword(password))

--- a/examples/WattMonitor/WattMonitor.ino
+++ b/examples/WattMonitor/WattMonitor.ino
@@ -15,6 +15,13 @@ bool connectWiSun(const char *id, const char *password)
   // 以前のPANAセッションを解除
   bp35a1.deleteSession();
 
+  // BP35A1のASCII変換モードがonである事を確認
+  if (!bp35a1.assureAsciiMode())
+  {
+    Serial.println("BP35A1::assure ascii mode failed");
+    return false;
+  }
+
   // B ルートの PASSWORD を送信
   if (!bp35a1.setPassword(password))
   {


### PR DESCRIPTION
## 概要

購入直後のBP35A1と`BP35A1-Wi-SUN-Arduino`ライブラリを利用するとスマートメータから値が取得できません。

具体的には瞬間電力が`0`となります（エアコンなどが稼働している状況）。

## 原因

ライブラリはBP35A1がASCII変換モードがonであることを期待していますが、ASCII変換モードのデフォルト値はoffです。ASCII変換モードはスマートメータから送信されたバイナリデータをBP35A1がASCIIデータに変換して返す機能です。このため、ライブラリがバイナリデータをASCIIデータと解釈しようとして、スマートメータから正しく値を受け取れなくなっています。

## 変更点

BP35A1のASCII変換モードがオンである事を確認する関数を追加しました。BP35A1のASCII変換モードの状態はフラッシュメモリ上に格納されており書き込み回数上限（10,000回以下）があります。そのため必要時にのみ書き込みを実施します。
