### PR TITLE
Fix overflow of _power variable when instantaneous power is negative.

### DIFF
--- a/bp35a1_UDP_Response.cpp
+++ b/bp35a1_UDP_Response.cpp
@@ -79,7 +79,7 @@ CollectionDay::CollectionDay(std::string data)
 
 InstantaneousPower::InstantaneousPower(std::string data)
 {
-  _power = strtol(data.c_str(), NULL, 16);
+  _power = static_cast<int>(strtoul(data.c_str(), NULL, 16));
 }
 
 InstantaneousAmperage::InstantaneousAmperage(std::string data)


### PR DESCRIPTION
## 概要
瞬時電力が負の値となる場合に `_power` 変数が正しく文字列型から数値型に変換されず、INT32_MAXとなる問題を改善することを提案します。

## 背景
瞬時電力はEchonet Liteでは順方向/逆方向電力の合計がsigned long (4 bytes)で出力されます。

例えば低圧スマートメータから瞬時電力 -100  W (0xFFFFFF9C)が返ってきた場合、strtol()を用いると4294967196と解釈されます。これはint32の範囲を超えるため、2147483647(= INT32_MAX)と変換されてしまいます。

## 修正内容
- BP35A1から受け取ったHEX表記を変換する処理を`strtol()`から`strtoul()`に変更。

## 動作確認
- 正および負の瞬時電力に対して、変数が適切に更新されることを確認しました

## その他
すばらしいライブラリを作成くださりありがとうございます。

この修正により本ライブラリがより広く使用されることを期待しています。